### PR TITLE
Cleanups, refactors, styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 data.json
-
+.idea/
+weirddb/
+dist/

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ struct UserData {
 fn App<G: Html>(cx: Scope, user_data: UserData) -> View<G> {
     let links = create_signal(cx, user_data.links);
     let github_data = services::UserGithubInfo::new(user_data.github_username.clone());
-    let read_me = create_ref(cx, github_data.read_me);
-    let parsed_readme = parse::<()>(&read_me).unwrap();
+    let readme = create_ref(cx, github_data.readme);
+    let parsed_readme = parse::<()>(&readme).unwrap();
     view! {
         cx,
         img(class="avatar", src=github_data.avatar_url)
@@ -55,24 +55,25 @@ fn main() {
     let html = sycamore::render_to_string(|cx| view! {cx, App(cloned_user_data)});
 
     // Open the index file
-    let mut html_file = fs::File::open("index.html").unwrap();
+    let mut html_file = fs::File::open("src/templates/default/index.html").unwrap();
     let mut index_template = String::new();
     html_file.read_to_string(&mut index_template).unwrap();
 
     // Create a new page from the template
     let mut generated_page =
-        fs::File::create(format!("{}_data.html", user_data.github_username)).unwrap();
+        fs::File::create(format!("dist/{}_data.html", user_data.github_username)).unwrap();
+    fs::copy("src/templates/default/styles.css", "dist/styles.css").expect("couldn't copy styles for some reason");
     write!(
         generated_page,
         "{}",
         index_template
-            .replace("%sycamore-body%", &html)
+            .replace("%sycamore-content%", &html)
             .replace("%sycamore-title%", &user_data.full_name)
     )
     .unwrap();
 
     println!(
-        "Page \"{}_data.html\" has been generated.",
-        user_data.github_username
+        "Page \"dist/{}_data.html\" has been generated.",
+             user_data.github_username
     );
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 pub struct UserGithubInfo {
     pub avatar_url: String,
     pub bio: String,
-    pub read_me: String,
+    pub readme: String,
 }
 
 impl UserGithubInfo {
@@ -33,7 +33,7 @@ impl UserGithubInfo {
             .to_string()
             .replace("\"", "");
         println!("Scraping README.md from GitHub...");
-        let mut read_me = client
+        let mut readme = client
             .get(format!(
                 "https://raw.githubusercontent.com/{}/{}/main/README.md",
                 username, username
@@ -42,12 +42,12 @@ impl UserGithubInfo {
             .expect("no readme file. is your readme file public?")
             .text()
             .unwrap();
-        read_me.remove(read_me.len() - 1);
-        read_me.remove(0);
+        readme.remove(readme.len() - 1);
+        readme.remove(0);
         Self {
             avatar_url,
             bio,
-            read_me,
+            readme,
         }
     }
 }

--- a/src/templates/default/index.html
+++ b/src/templates/default/index.html
@@ -3,9 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>%sycamore-title%</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-    %sycamore-body%
+    <div class="content">
+        %sycamore-content%
+    </div>
 </body>
 </html>

--- a/src/templates/default/styles.css
+++ b/src/templates/default/styles.css
@@ -3,27 +3,27 @@
 }
 
 :root {
-    --bg: #121212;
+    --background: #222222;
     --dark-gray:  #8a8a8a;
-    --fg: #ffffff;
+    --foreground: #bbbbbb;
+    --link: #ff9999;
 }
 
-html, body{
+body{
     margin: 0;
     padding: 0;
+    background-color: var(--background);
+    color: var(--foreground);
 }
 
-html{
-    background-color: var(--bg);
-    color: var(--fg);
-}
 
-body {
-    max-width: 50ch;
-    margin-inline: auto;
+p,a,h1,h2,h3,h4,h5 {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    text-align: center;
-    line-height: 1.5;
+}
+
+a {
+    color: var(--link);
+    text-decoration: none;
 }
 
 .avatar {
@@ -33,6 +33,16 @@ body {
     border-radius: 50%;
 }
 
+.content {
+    margin: 50px 0px 50px 0px;
+    border: 1px var(--foreground) solid;
+    border-radius: 6px;
+    padding: 24px;
+    max-width: 80ch;
+    margin-inline: auto;
+    line-height: 1.5;
+}
+
 .user-name, .full-name {
     font-weight: normal;
     margin: 0;
@@ -40,7 +50,7 @@ body {
 
 .full-name {
     margin-top:1em ;
-    color: var(--fg);
+    color: var(--foreground);
 }
 
 .user-name {
@@ -53,12 +63,11 @@ body {
 
 .links-container {
     display: grid;
-    grid-gap: 0ch;
 }
 
 .link {
     text-decoration: none;
-    color: var(--fg);
+    color: var(--foreground);
 }
 
 .link::before {


### PR DESCRIPTION
- moved index.html and styles.css to src/templates/default
- will now export the generated files to /dist
- updated styles with some common practices
  - removed use of `ch` - nobody uses this because it's
    only useful for monospaced fonts
  - removed direct injections to `html` not because it's
    bad practice or anything but because all of the styles
    that were applied to it could be moved down to the `body` level,
    which is where they are now
  - apply `font-family` directly to text instead of indirect attribution
- added a div of class `content` +css where the main content lives
- added styles for `a`, a nice highlight color
- renamed variable `read_me` to` readme` - totally nitting
- beefed up the .gitignore